### PR TITLE
Support getIn path

### DIFF
--- a/lib/ListForm.js
+++ b/lib/ListForm.js
@@ -98,6 +98,28 @@ function () {
       return this.items[index];
     }
   }, {
+    key: "getIn",
+    value: function getIn(path) {
+      var i = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
+
+      if (path.length === 0) {
+        return this;
+      }
+
+      var key = path[i];
+      var item = this.get(key);
+
+      if (!item) {
+        throw new Error("No item found at path \"".concat(path.slice(0, i + 1).join('.'), "\""));
+      }
+
+      if (path.length - 1 === i) {
+        return item;
+      }
+
+      return item.getIn(path, i + 1);
+    }
+  }, {
     key: "remove",
     value: function remove(index) {
       var items = (0, _util.shallowCopyArray)(this.items);

--- a/lib/MapForm.js
+++ b/lib/MapForm.js
@@ -72,6 +72,28 @@ function () {
       return this.items[key];
     }
   }, {
+    key: "getIn",
+    value: function getIn(path) {
+      var i = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
+
+      if (path.length === 0) {
+        return this;
+      }
+
+      var key = path[i];
+      var item = this.get(key);
+
+      if (!item) {
+        throw new Error("No item found at path \"".concat(path.slice(0, i + 1).join('.'), "\""));
+      }
+
+      if (path.length - 1 === i) {
+        return item;
+      }
+
+      return item.getIn(path, i + 1);
+    }
+  }, {
     key: "remove",
     value: function remove(key) {
       if (key in this.items) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2749,7 +2749,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2770,12 +2771,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2790,17 +2793,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2917,7 +2923,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2929,6 +2936,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2943,6 +2951,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2950,12 +2959,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2974,6 +2985,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3054,7 +3066,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3066,6 +3079,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3151,7 +3165,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3187,6 +3202,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3206,6 +3222,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3249,12 +3266,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2749,8 +2749,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2771,14 +2770,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2793,20 +2790,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2923,8 +2917,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2936,7 +2929,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2951,7 +2943,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2959,14 +2950,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2985,7 +2974,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3066,8 +3054,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3079,7 +3066,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3165,8 +3151,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3202,7 +3187,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3222,7 +3206,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3266,14 +3249,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/ListForm.js
+++ b/src/ListForm.js
@@ -75,6 +75,25 @@ class ListForm {
     return this.items[index];
   }
 
+  getIn(path, i=0) {
+    if (path.length === 0) {
+      return this;
+    }
+
+    const key = path[i];
+    const item = this.get(key);
+
+    if (!item) {
+      throw new Error(`No item found at path "${path.slice(0, i + 1).join('.')}"`);
+    }
+
+    if (path.length - 1 === i) {
+      return item;
+    }
+
+    return item.getIn(path, i + 1);
+  }
+
   remove(index) {
     const items = shallowCopyArray(this.items);
     items.splice(index, 1);

--- a/src/MapForm.js
+++ b/src/MapForm.js
@@ -50,6 +50,25 @@ class MapForm {
     return this.items[key];
   }
 
+  getIn(path, i=0) {
+    if (path.length === 0) {
+      return this;
+    }
+
+    const key = path[i];
+    const item = this.get(key);
+
+    if (!item) {
+      throw new Error(`No item found at path "${path.slice(0, i + 1).join('.')}"`);
+    }
+
+    if (path.length - 1 === i) {
+      return item;
+    }
+
+    return item.getIn(path, i + 1);
+  }
+
   remove(key) {
     if (key in this.items) {
       const items = shallowCopyObject(this.items);

--- a/test/Form.test.js
+++ b/test/Form.test.js
@@ -24,4 +24,17 @@ describe('Form', () => {
       person: ['jennifer@example.com', 'Jennifer']
     });
   });
+
+  it('must get deep values in a mixed list/map form situation', () => {
+    form = createMapForm()
+      .put(
+        'person',
+        createListForm()
+          .push(email)
+          .push(name)
+      );
+      
+    expect(form.getIn(['person', 0])).to.deep.equal(email);
+    expect(form.getIn(['person', 1])).to.deep.equal(name);
+  });
 });

--- a/test/ListForm.test.js
+++ b/test/ListForm.test.js
@@ -126,6 +126,26 @@ describe('ListForm', () => {
     });
   });
 
+  describe('getIn', () => {
+    it('must fail when the path does not exist', () => {
+      form = createListForm().push(createField({value: '1'}));
+      expect(() => form.getIn([1])).to.throw(/No item found at path/);
+    });
+
+    it('must support get on root level with empty paths', () => {
+      form = createListForm().push(createField({value: '1'}));
+      expect(form.getIn([])).to.deep.equal(form);
+    });
+
+    it('must get in deeply nested list structures', () => {
+      const field = createField({value: 'jen'});
+      form = createListForm()
+        .push(createListForm()
+          .push(field));
+      expect(form.getIn([0, 0])).to.deep.equal(field);
+    });
+  });
+
   describe('move', () => {
     beforeEach(() => {
       form = createListForm()

--- a/test/MapForm.test.js
+++ b/test/MapForm.test.js
@@ -157,6 +157,37 @@ describe('MapForm', () => {
     });
   });
 
+  describe('getIn', () => {
+    it('must support get value', () => {
+      const field = createField({value: 'tom@example.com'});
+      const form = createMapForm()
+        .put('email', field);
+      expect(form.getIn(['email'])).to.deep.equal(field);
+    });
+
+    it('must support deep get value', () => {
+      const field = createField({value: 'tom@example.com'});
+      const form = createMapForm()
+        .put('contactInfo', createMapForm()
+          .put('email', field));
+      expect(form.getIn(['contactInfo', 'email'])).to.deep.equal(field);
+    });
+
+    it('must support get on root level with empty paths', () => {
+      const form = createMapForm()
+        .put('contactInfo', createMapForm()
+          .put('email', createField({value: 'tom@example.com'})));
+      expect(form.getIn([])).to.deep.equal(form);
+    });
+
+    it('must throw on missing sub paths', () => {
+      const field = createField({value: 'tom@example.com'});
+      const form = createMapForm()
+        .put('email', field);
+      expect(() => form.getIn(['contactInfo', 'email'])).to.throw(/No item found at path "contactInfo"/);
+    });
+  });
+
   describe('touched', () => {
     it('must assume that the form is initially pristine', () => {
       form = createMapForm();


### PR DESCRIPTION
# Why?

We had a use-case where the native support of `getIn` would have been very convenient. We have a more complex multi-step-dialog using a _hierarchical_ `MapForm`, where we check _intermediate validations_ of some specific form fields, so that the user immediately sees that some fields are not correct, instead of pointing this out just at the very last page, when the user submits the full form.
To make this more generic and re-usable, we defined a configuration object which defines on which page, which fields of the form need to be validated, similar to:

```javascript
const dialogConfig = [
  {
    title: "Step: 1: User",
    earlyValidate: [['person', 'name']]
  },
  {
    title: "Step: 2: Address",
    earlyValidate: [['person', 'street'], ['person', 'zipcode']]
  },
  {
    title: "Step: 3: Verify & Submit",
    earlyValidate: []
  }
];
```

Given this configuration object, and a `getIn` method at hand, it would be very easy to implement this intermediate validation. However, we get to implement this method as a utility function like `function getIn(form, path)` so far. Hence, it would be very convenient if _formalistic_ would ship this function out-of-the-box :)

# What?

- support `getIn` for MapForm
- support `getIn` for ListForm
- unit-tests for `MapForm`, `ListForm` and `Form` (for mixed scenario)

# Open Questions?

- I did not extend `Field` with a `getIn` function, because it also does not have a `get` function. So please let me know in case such a method should be added, which behaves similar to `field.updateIn()`, which only works on an empty path. However, I'm not sure in which scenario such a `field.getIn([])` function should be useful.